### PR TITLE
Issue fix no actual shutdown in qtx120x.py and qtx120xTerminal.py

### DIFF
--- a/qtx120x.py
+++ b/qtx120x.py
@@ -117,63 +117,11 @@ class UPSStatusWindow(QWidget):
         self.setLayout(layout)
         # Populate initial data
         self.update_status()
+        self.update_status()
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_status)
         self.timer.start(30000)  ## milliseconds
         self.shutdown = False
-
-    # def populate_initial_data(self):
-    #     voltage, capacity = read_voltage_and_capacity(bus)
-    #     cpu_volts = read_cpu_volts()
-    #     cpu_amps = read_cpu_amps()
-    #     cpu_temp = read_cpu_temp()
-    #     input_voltage = read_input_voltage()
-    #     fan_rpm = get_fan_rpm()
-    #     pwr_use = power_consumption_watts()
-    #     pld_state = get_pld_state()
-    #     warn_status = ""
-
-    #     if capacity >= 90: # up = disabled
-    #         charge_status = "<FONT COLOR='#FF0000'>disabled</FONT>"
-    #         InputDevice(CHG_ONOFF_PIN,pull_up=True)
-    #     else: # down = enabled
-    #         charge_status = "<FONT COLOR='#FF0000'>enabled</FONT>"
-    #         InputDevice(CHG_ONOFF_PIN,pull_up=False)
-
-    #     if pld_state == 1:
-    #         power_status = "<FONT COLOR='#00FF00'>\U00002714 AC Power: OK! \U00002714<BR/>\U00002714 Power Adapter: OK! \U00002714</FONT>"
-    #     else:
-    #         power_status = "<FONT COLOR='#FF0000'>\U000026A0 Power Loss OR Power Adapter Failure \U000026A0</FONT>"
-
-    #     if pld_state != 1 and capacity >=51:
-    #         warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>Running on UPS Backup Power<BR/>Batteries @{capacity:.2f}&#37;"
-    #     elif pld_state != 1 and capacity <= 50 and capacity >= 25:
-    #         warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>UPS Power levels approaching critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
-    #     elif pld_state != 1 and capacity <= 24 and capacity >= 16:
-    #         warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 16pt;>UPS Power levels critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
-    #     elif pld_state != 1 and capacity <= 15:
-    #         warn_status = "<FONT COLOR='#FF0000';FONT-SIZE: 18pt;>UPS Power failure imminent!<BR/>Auto shutdown to occur in 5 minutes!</FONT><BR/>"
-    #         call("sudo shutdown -P +5 &quot;Power failure, shutdown in 5 minutes.&quot;", shell=True)
-    #     else:
-    #         warn_status = ""
-
-    #     text = (
-    #         f"<FONT COLOR='#9C009C'>-=-=-=-=-=</FONT><FONT COLOR='#FF00FF'> X120x Stats </FONT><FONT COLOR='#9C009C'>=-=-=-=-=-</FONT><BR/>"
-    #         f"UPS Voltage: <FONT COLOR='#FF0000'>{voltage:.3f}V</FONT><BR/>"
-    #         f"Battery: <FONT COLOR='#FF0000'>{capacity:.3f}&#37;</FONT><BR/>"
-    #         f"Charging: </FONT>{charge_status}</FONT><BR/>"
-    #         f"<FONT COLOR='#9C009C'>-=-=-=-=-=</FONT><FONT COLOR='#FF00FF'> RPi5 Stats </FONT><FONT COLOR='#9C009C'>=-=-=-=-=-</FONT><BR/>"
-    #         f"Input Voltage: <FONT COLOR='#FF0000'>{input_voltage:.3f}V</FONT><BR/>"
-    #         f"CPU Volts: <FONT COLOR='#FF0000'>{cpu_volts:.3f}V</FONT><BR/>"
-    #         f"CPU Amps: <FONT COLOR='#FF0000'>{cpu_amps:.3f}A</FONT><BR/>"
-    #         f"System Watts: <FONT COLOR='#FF0000'>{pwr_use:.3f}W</FONT><BR/>"
-    #         f"CPU Temp: <FONT COLOR='#FF0000'>{cpu_temp:.1f}&deg;C</FONT><BR/>"
-    #         f"Fan RPM: <FONT COLOR='#FF0000'>{fan_rpm}</FONT><BR/>"
-    #         f"<FONT COLOR='#9C009C'>-=-=-= <FONT COLOR='#FF00FF'>\U000026A1 Power Status \U000026A1 </FONT><FONT COLOR='#9C009C'>=-=-=-</FONT><BR/>"
-    #         f"{power_status}<BR/>"
-    #         f"{warn_status}"
-    #     )
-    #     self.label.setText(text)
 
     def update_status(self):
         voltage, capacity = read_voltage_and_capacity(bus)
@@ -204,6 +152,8 @@ class UPSStatusWindow(QWidget):
             warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>UPS Power levels approaching critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
         elif pld_state != 1 and capacity <= 24 and capacity >= 16:
             warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 16pt;>UPS Power levels critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
+        elif pld_state != 1 and capacity <= 15 and not self.shutdown:
+            self.shutdown = True
         elif pld_state != 1 and capacity <= 15 and not self.shutdown:
             self.shutdown = True
             warn_status = "<FONT COLOR='#FF0000';FONT-SIZE: 18pt;>UPS Power failure imminent!<BR/>Auto shutdown to occur in 5 minutes!</FONT><BR/>"

--- a/qtx120x.py
+++ b/qtx120x.py
@@ -116,63 +116,64 @@ class UPSStatusWindow(QWidget):
         layout.addWidget(self.label)
         self.setLayout(layout)
         # Populate initial data
-        self.populate_initial_data()
+        self.update_status()
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_status)
         self.timer.start(30000)  ## milliseconds
+        self.shutdown = False
 
-    def populate_initial_data(self):
-        voltage, capacity = read_voltage_and_capacity(bus)
-        cpu_volts = read_cpu_volts()
-        cpu_amps = read_cpu_amps()
-        cpu_temp = read_cpu_temp()
-        input_voltage = read_input_voltage()
-        fan_rpm = get_fan_rpm()
-        pwr_use = power_consumption_watts()
-        pld_state = get_pld_state()
-        warn_status = ""
+    # def populate_initial_data(self):
+    #     voltage, capacity = read_voltage_and_capacity(bus)
+    #     cpu_volts = read_cpu_volts()
+    #     cpu_amps = read_cpu_amps()
+    #     cpu_temp = read_cpu_temp()
+    #     input_voltage = read_input_voltage()
+    #     fan_rpm = get_fan_rpm()
+    #     pwr_use = power_consumption_watts()
+    #     pld_state = get_pld_state()
+    #     warn_status = ""
 
-        if capacity >= 90: # up = disabled
-            charge_status = "<FONT COLOR='#FF0000'>disabled</FONT>"
-            InputDevice(CHG_ONOFF_PIN,pull_up=True)
-        else: # down = enabled
-            charge_status = "<FONT COLOR='#FF0000'>enabled</FONT>"
-            InputDevice(CHG_ONOFF_PIN,pull_up=False)
+    #     if capacity >= 90: # up = disabled
+    #         charge_status = "<FONT COLOR='#FF0000'>disabled</FONT>"
+    #         InputDevice(CHG_ONOFF_PIN,pull_up=True)
+    #     else: # down = enabled
+    #         charge_status = "<FONT COLOR='#FF0000'>enabled</FONT>"
+    #         InputDevice(CHG_ONOFF_PIN,pull_up=False)
 
-        if pld_state == 1:
-            power_status = "<FONT COLOR='#00FF00'>\U00002714 AC Power: OK! \U00002714<BR/>\U00002714 Power Adapter: OK! \U00002714</FONT>"
-        else:
-            power_status = "<FONT COLOR='#FF0000'>\U000026A0 Power Loss OR Power Adapter Failure \U000026A0</FONT>"
+    #     if pld_state == 1:
+    #         power_status = "<FONT COLOR='#00FF00'>\U00002714 AC Power: OK! \U00002714<BR/>\U00002714 Power Adapter: OK! \U00002714</FONT>"
+    #     else:
+    #         power_status = "<FONT COLOR='#FF0000'>\U000026A0 Power Loss OR Power Adapter Failure \U000026A0</FONT>"
 
-        if pld_state != 1 and capacity >=51:
-            warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>Running on UPS Backup Power<BR/>Batteries @{capacity:.2f}&#37;"
-        elif pld_state != 1 and capacity <= 50 and capacity >= 25:
-            warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>UPS Power levels approaching critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
-        elif pld_state != 1 and capacity <= 24 and capacity >= 16:
-            warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 16pt;>UPS Power levels critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
-        elif pld_state != 1 and capacity <= 15:
-            warn_status = "<FONT COLOR='#FF0000';FONT-SIZE: 18pt;>UPS Power failure imminent!<BR/>Auto shutdown to occur in 5 minutes!</FONT><BR/>"
-            call("sudo shutdown -P +5 &quot;Power failure, shutdown in 5 minutes.&quot;", shell=True)
-        else:
-            warn_status = ""
+    #     if pld_state != 1 and capacity >=51:
+    #         warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>Running on UPS Backup Power<BR/>Batteries @{capacity:.2f}&#37;"
+    #     elif pld_state != 1 and capacity <= 50 and capacity >= 25:
+    #         warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>UPS Power levels approaching critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
+    #     elif pld_state != 1 and capacity <= 24 and capacity >= 16:
+    #         warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 16pt;>UPS Power levels critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
+    #     elif pld_state != 1 and capacity <= 15:
+    #         warn_status = "<FONT COLOR='#FF0000';FONT-SIZE: 18pt;>UPS Power failure imminent!<BR/>Auto shutdown to occur in 5 minutes!</FONT><BR/>"
+    #         call("sudo shutdown -P +5 &quot;Power failure, shutdown in 5 minutes.&quot;", shell=True)
+    #     else:
+    #         warn_status = ""
 
-        text = (
-            f"<FONT COLOR='#9C009C'>-=-=-=-=-=</FONT><FONT COLOR='#FF00FF'> X120x Stats </FONT><FONT COLOR='#9C009C'>=-=-=-=-=-</FONT><BR/>"
-            f"UPS Voltage: <FONT COLOR='#FF0000'>{voltage:.3f}V</FONT><BR/>"
-            f"Battery: <FONT COLOR='#FF0000'>{capacity:.3f}&#37;</FONT><BR/>"
-            f"Charging: </FONT>{charge_status}</FONT><BR/>"
-            f"<FONT COLOR='#9C009C'>-=-=-=-=-=</FONT><FONT COLOR='#FF00FF'> RPi5 Stats </FONT><FONT COLOR='#9C009C'>=-=-=-=-=-</FONT><BR/>"
-            f"Input Voltage: <FONT COLOR='#FF0000'>{input_voltage:.3f}V</FONT><BR/>"
-            f"CPU Volts: <FONT COLOR='#FF0000'>{cpu_volts:.3f}V</FONT><BR/>"
-            f"CPU Amps: <FONT COLOR='#FF0000'>{cpu_amps:.3f}A</FONT><BR/>"
-            f"System Watts: <FONT COLOR='#FF0000'>{pwr_use:.3f}W</FONT><BR/>"
-            f"CPU Temp: <FONT COLOR='#FF0000'>{cpu_temp:.1f}&deg;C</FONT><BR/>"
-            f"Fan RPM: <FONT COLOR='#FF0000'>{fan_rpm}</FONT><BR/>"
-            f"<FONT COLOR='#9C009C'>-=-=-= <FONT COLOR='#FF00FF'>\U000026A1 Power Status \U000026A1 </FONT><FONT COLOR='#9C009C'>=-=-=-</FONT><BR/>"
-            f"{power_status}<BR/>"
-            f"{warn_status}"
-        )
-        self.label.setText(text)
+    #     text = (
+    #         f"<FONT COLOR='#9C009C'>-=-=-=-=-=</FONT><FONT COLOR='#FF00FF'> X120x Stats </FONT><FONT COLOR='#9C009C'>=-=-=-=-=-</FONT><BR/>"
+    #         f"UPS Voltage: <FONT COLOR='#FF0000'>{voltage:.3f}V</FONT><BR/>"
+    #         f"Battery: <FONT COLOR='#FF0000'>{capacity:.3f}&#37;</FONT><BR/>"
+    #         f"Charging: </FONT>{charge_status}</FONT><BR/>"
+    #         f"<FONT COLOR='#9C009C'>-=-=-=-=-=</FONT><FONT COLOR='#FF00FF'> RPi5 Stats </FONT><FONT COLOR='#9C009C'>=-=-=-=-=-</FONT><BR/>"
+    #         f"Input Voltage: <FONT COLOR='#FF0000'>{input_voltage:.3f}V</FONT><BR/>"
+    #         f"CPU Volts: <FONT COLOR='#FF0000'>{cpu_volts:.3f}V</FONT><BR/>"
+    #         f"CPU Amps: <FONT COLOR='#FF0000'>{cpu_amps:.3f}A</FONT><BR/>"
+    #         f"System Watts: <FONT COLOR='#FF0000'>{pwr_use:.3f}W</FONT><BR/>"
+    #         f"CPU Temp: <FONT COLOR='#FF0000'>{cpu_temp:.1f}&deg;C</FONT><BR/>"
+    #         f"Fan RPM: <FONT COLOR='#FF0000'>{fan_rpm}</FONT><BR/>"
+    #         f"<FONT COLOR='#9C009C'>-=-=-= <FONT COLOR='#FF00FF'>\U000026A1 Power Status \U000026A1 </FONT><FONT COLOR='#9C009C'>=-=-=-</FONT><BR/>"
+    #         f"{power_status}<BR/>"
+    #         f"{warn_status}"
+    #     )
+    #     self.label.setText(text)
 
     def update_status(self):
         voltage, capacity = read_voltage_and_capacity(bus)
@@ -203,9 +204,16 @@ class UPSStatusWindow(QWidget):
             warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 14pt;>UPS Power levels approaching critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
         elif pld_state != 1 and capacity <= 24 and capacity >= 16:
             warn_status = f"<FONT COLOR='#FF0000';FONT-SIZE: 16pt;>UPS Power levels critical,<BR/>Batteries @{capacity:.2f}&#37;</FONT><BR/>"
-        elif pld_state != 1 and capacity <= 15:
+        elif pld_state != 1 and capacity <= 15 and not self.shutdown:
+            self.shutdown = True
             warn_status = "<FONT COLOR='#FF0000';FONT-SIZE: 18pt;>UPS Power failure imminent!<BR/>Auto shutdown to occur in 5 minutes!</FONT><BR/>"
-            call("sudo shutdown -P +5 &quot;Power failure, shutdown in 5 minutes.&quot;", shell=True)
+            call("sudo shutdown -P +5 'Power failure, shutdown in 5 minutes.'", shell=True)
+        elif pld_state != 1 and self.shutdown:
+            warn_status = "<FONT COLOR='#FF0000';FONT-SIZE: 18pt;>UPS Power failure imminent!<BR/>Auto shutdown to occur within 5 minutes!</FONT><BR/>"
+        elif pld_state == 1 and self.shutdown:
+            call("sudo shutdown -c 'Shutdown is cancelled'", shell=True)
+            warn_status = "<FONT COLOR='#00FF00';FONT-SIZE: 18pt;>AC Power has been restored<BR/>Auto shutdown has been cancelled!</FONT><BR/>"
+            self.shutdown = False
         else:
             warn_status = ""
 

--- a/qtx120x.py
+++ b/qtx120x.py
@@ -32,7 +32,6 @@ def read_voltage_and_capacity(bus):
     voltage = voltage_swapped * 1.25 / 1000 / 16 # convert to understandable voltage
     capacity_swapped = struct.unpack("<H", struct.pack(">H", capacity_read))[0] # big endian to little endian
     capacity = capacity_swapped / 256 # convert to 1-100% scale
-
     return voltage, capacity
 
 def get_pld_state():
@@ -116,12 +115,11 @@ class UPSStatusWindow(QWidget):
         layout.addWidget(self.label)
         self.setLayout(layout)
         # Populate initial data
-        self.update_status()
+        self.shutdown = False
         self.update_status()
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_status)
         self.timer.start(30000)  ## milliseconds
-        self.shutdown = False
 
     def update_status(self):
         voltage, capacity = read_voltage_and_capacity(bus)

--- a/qtx120xTerminal.py
+++ b/qtx120xTerminal.py
@@ -83,7 +83,7 @@ def power_consumption_watts():
     wattage = sum(amperages[key] * voltages[key] for key in amperages if key in voltages)
     return wattage
 
-def display_status(shutdown: Boolean):
+def display_status(shutdown):
     voltage, capacity = read_voltage_and_capacity(bus)
     cpu_volts = read_cpu_volts()
     cpu_amps = read_cpu_amps()
@@ -112,13 +112,13 @@ def display_status(shutdown: Boolean):
         warn_status = f"UPS Power levels approaching critical | Batteries @ {capacity:.2f}%"
     elif pld_state != 1 and capacity <= 24 and capacity >= 16:
         warn_status = f"UPS Power levels critical | Batteries @ {capacity:.2f}%"
-    elif pld_state != 1 and capacity <= 15 and not self.shutdown:
+    elif pld_state != 1 and capacity <= 15 and not shutdown:
         shutdown = True
         warn_status = "UPS Power failure imminent! Auto shutdown in 5 minutes!"
         call("sudo shutdown -P +5 'Power failure, shutdown in 5 minutes.'", shell=True)
-    elif pld_state != 1 and self.shutdown:
+    elif pld_state != 1 and shutdown:
         warn_status = "UPS Power failure imminent! Auto shutdown to occur within 5 minutes!"
-    elif pld_state == 1 and self.shutdown:
+    elif pld_state == 1 and shutdown:
         call("sudo shutdown -c 'Shutdown is cancelled'", shell=True)
         warn_status = "AC Power has been restored. Auto shutdown has been cancelled!"
         shutdown = False

--- a/qtx120xTerminal.py
+++ b/qtx120xTerminal.py
@@ -83,7 +83,7 @@ def power_consumption_watts():
     wattage = sum(amperages[key] * voltages[key] for key in amperages if key in voltages)
     return wattage
 
-def display_status():
+def display_status(shutdown: Boolean):
     voltage, capacity = read_voltage_and_capacity(bus)
     cpu_volts = read_cpu_volts()
     cpu_amps = read_cpu_amps()
@@ -112,9 +112,16 @@ def display_status():
         warn_status = f"UPS Power levels approaching critical | Batteries @ {capacity:.2f}%"
     elif pld_state != 1 and capacity <= 24 and capacity >= 16:
         warn_status = f"UPS Power levels critical | Batteries @ {capacity:.2f}%"
-    elif pld_state != 1 and capacity <= 15:
+    elif pld_state != 1 and capacity <= 15 and not self.shutdown:
+        shutdown = True
         warn_status = "UPS Power failure imminent! Auto shutdown in 5 minutes!"
         call("sudo shutdown -P +5 'Power failure, shutdown in 5 minutes.'", shell=True)
+    elif pld_state != 1 and self.shutdown:
+        warn_status = "UPS Power failure imminent! Auto shutdown to occur within 5 minutes!"
+    elif pld_state == 1 and self.shutdown:
+        call("sudo shutdown -c 'Shutdown is cancelled'", shell=True)
+        warn_status = "AC Power has been restored. Auto shutdown has been cancelled!"
+        shutdown = False
     else:
         warn_status = ""
 
@@ -134,11 +141,13 @@ def display_status():
     if warn_status:
         print(f"WARNING: {warn_status}")
     print("======================================")
+    return shutdown
 
 if __name__ == "__main__":
+    shutdown = False
     try:
         while True:
-            display_status()
+            shutdown = display_status(shutdown)
             time.sleep(30)  # Update every 30 seconds
     except KeyboardInterrupt:
         print("\nMonitoring stopped.")


### PR DESCRIPTION
There is an issue with qtx120x.py and qtx120xTerminal.py

They looped through the decision tree every minute/cycle. Determined AC failure and again and again initiated a 5 minute shutdown, but thus actually postponing the shutdown.

I changed the code so it only submits the shutdown once. 
Added code to handle  ac restore in that time period.

Additionally:
Removed the initialization function and just call the update function for initialization. Since it is exactly the same code.
Changed quotes in warnings for the shutdown message.

