### PR TITLE
Define instance var before attempting to use it

### DIFF
--- a/qtx120x.py
+++ b/qtx120x.py
@@ -104,6 +104,8 @@ def power_consumption_watts():
 class UPSStatusWindow(QWidget):
     def __init__(self):
         super().__init__()
+        self.shutdown = False
+
         self.setWindowTitle(" X120X UPS Status ")
         self.setStyleSheet("BACKGROUND-COLOR: #2C132C;")
         self.resize(450, 380)
@@ -115,13 +117,13 @@ class UPSStatusWindow(QWidget):
         layout = QVBoxLayout(self)
         layout.addWidget(self.label)
         self.setLayout(layout)
+
         # Populate initial data
         self.update_status()
         self.update_status()
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_status)
         self.timer.start(30000)  ## milliseconds
-        self.shutdown = False
 
     def update_status(self):
         voltage, capacity = read_voltage_and_capacity(bus)


### PR DESCRIPTION
Seeing this error

```
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
Traceback (most recent call last):
  File "/home/HOME/pg/x120x/qtx120x.py", line 190, in <module>
    window = UPSStatusWindow()
             ^^^^^^^^^^^^^^^^^
  File "/home/HOME/pg/x120x/qtx120x.py", line 119, in __init__
    self.update_status()
  File "/home/HOME/pg/x120x/qtx120x.py", line 163, in update_status
    elif pld_state == 1 and self.shutdown:
                            ^^^^^^^^^^^^^
AttributeError: 'UPSStatusWindow' object has no attribute 'shutdown'
```

Ensure shutdown is defined before we call into `update_status`